### PR TITLE
[Feat] 사용자별 질문 추천 기능 구현

### DIFF
--- a/question-service/src/main/java/com/team9/question_service/controller/QuestionController.java
+++ b/question-service/src/main/java/com/team9/question_service/controller/QuestionController.java
@@ -39,6 +39,19 @@ public class QuestionController {
         QuestionResponse question = questionService.getQuestionDetail(id, userId); // userId 전달
         return ResponseEntity.ok(CustomResponse.ok(question));
     }
+    /**
+     * 로그인한 사용자에게 개인화된 질문을 추천합니다.
+     * 비로그인 시에는 오늘의 질문을 반환합니다.
+     *
+     * @param userId API Gateway에서 전달하는 사용자 ID
+     * @return 추천 질문 DTO
+     */
+    @GetMapping("/recommend")
+    public ResponseEntity<CustomResponse<QuestionResponse>> getRecommendedQuestion(
+            @RequestHeader(value = "X-User-Id", required = false) Long userId) {
+        QuestionResponse question = questionService.getRecommendedQuestion(userId);
+        return ResponseEntity.ok(CustomResponse.ok(question));
+    }
 
     @GetMapping("/today")
     public ResponseEntity<CustomResponse<QuestionResponse>> getTodayQuestion(

--- a/question-service/src/main/java/com/team9/question_service/remote/UserServiceClient.java
+++ b/question-service/src/main/java/com/team9/question_service/remote/UserServiceClient.java
@@ -1,0 +1,26 @@
+package com.team9.question_service.remote;
+
+import com.team9.common.response.CustomResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+/**
+ * user-service와의 내부 통신을 위한 Feign Client 인터페이스
+ */
+@FeignClient("user-service") // Eureka에 등록된 "user-service"를 찾아 연결합니다.
+public interface UserServiceClient {
+
+    /**
+     * user-service의 내부 API를 호출하여 특정 사용자의 관심 카테고리 목록을 가져옵니다.
+     * API Gateway를 거치지 않는 서비스 간 통신을 위해 '/internal' 경로를 사용하는 것이 일반적입니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @return CustomResponse 형태의 응답. 결과 데이터는 String 타입의 카테고리 이름 리스트입니다.
+     */
+    @GetMapping("/internal/users/interests")
+    ResponseEntity<CustomResponse<List<String>>> getUserInterests(@RequestParam("userId") Long userId);
+}

--- a/question-service/src/main/java/com/team9/question_service/repository/QuestionRepository.java
+++ b/question-service/src/main/java/com/team9/question_service/repository/QuestionRepository.java
@@ -1,15 +1,46 @@
 package com.team9.question_service.repository;
 
+import com.team9.common.domain.Category;
 import com.team9.question_service.domain.Question;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import com.team9.common.domain.Category;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Page<Question> findByCategory(Category category, Pageable pageable);
 
     Question findFirstByCreatedAtBetweenOrderByCreatedAtDesc(LocalDateTime start, LocalDateTime end);
+
+    // 네이티브 쿼리 사용하는 이유: JPQL 표준에 DB에서 직접 무작위 정렬을 하는 기능이 없기 때문
+    /**
+     * 주어진 카테고리 목록에 속하면서, 제외할 ID 목록에 포함되지 않는 질문을 랜덤으로 1개 조회합니다.
+     *
+     * @param categories 관심 카테고리 목록
+     * @param excludedIds 제외할 질문 ID 목록 (이미 답변한 질문)
+     * @return 랜덤으로 선택된 Question (Optional)
+     */
+    @Query(value = "SELECT * FROM question q " +
+            "WHERE q.category IN :categories AND q.id NOT IN :excludedIds AND q.is_active = true " +
+            "ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Question> findRandomQuestionByCategoriesAndNotInIds(
+            @Param("categories") List<String> categories,
+            @Param("excludedIds") List<Long> excludedIds
+    );
+
+    /**
+     * 모든 질문 중에서 제외할 ID 목록에 포함되지 않는 질문을 랜덤으로 1개 조회합니다. (Fallback 용)
+     *
+     * @param excludedIds 제외할 질문 ID 목록
+     * @return 랜덤으로 선택된 Question (Optional)
+     */
+    @Query(value = "SELECT * FROM question q " +
+            "WHERE q.id NOT IN :excludedIds AND q.is_active = true " +
+            "ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Question> findRandomQuestionNotInIds(@Param("excludedIds") List<Long> excludedIds);
 }


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- #36

## 🔍 작업 상세 (Implementation Details)
- UserServiceClient 구현
> user-service의 GET /api/users/interests API를 호출하여 사용자의 관심 카테고리 목록을 조회하는 Feign Client를 구현합니다.
- QuestionService 로직 추가
> UserServiceClient와 AnswerServiceClient를 호출하여 필요한 데이터를 수집합니다.
>"관심 카테고리에 속하면서, 아직 답변하지 않은 질문"을 랜덤으로 1개 조회하는 비즈니스 로직을 작성합니다.
> 추천할 질문이 없을 경우(비로그인 or 관심 카테고리의 모든 질문에 답변함 등)에 대한 예외 처리 또는 대체 로직(Fallback)을 구현합니다.
- QuestionRepository 쿼리 추가
> 관심 카테고리 목록과 제외할 질문 ID 목록을 조건으로 랜덤 질문을 조회하는 커스텀 쿼리를 추가합니다.
- QuestionController 엔드포인트 추가
> 우선 /api/questions/recommend 로 생성해서 기존 기능인 /api/questions/today 와 분리했습니다.

## 📝 추가 정보 (Additional Information)
- 테스트 차후 진행하나 도커 빌드 및 실행에는 오류 없음을 확인했습니다.