### PR TITLE
[Feat] 사용자별 질문 추천 기능 구현(2)

### DIFF
--- a/question-service/src/main/java/com/team9/question_service/dto/UserProfileResponseDto.java
+++ b/question-service/src/main/java/com/team9/question_service/dto/UserProfileResponseDto.java
@@ -1,0 +1,21 @@
+package com.team9.question_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * user-service로부터 받을 사용자 프로필 응답 DTO.
+ * question-service는 이 중에서 interestCategories 필드만 사용합니다.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponseDto {
+    // user-service가 다른 필드(예: nickname, email 등)를 함께 보내주더라도,
+    // question-service는 관심사 목록만 필요하므로 해당 필드만 정의합니다.
+    // JSON 라이브러리(Jackson)는 DTO에 정의되지 않은 필드는 자동으로 무시합니다.
+    private List<String> interestCategories;
+}

--- a/question-service/src/main/java/com/team9/question_service/remote/UserServiceClient.java
+++ b/question-service/src/main/java/com/team9/question_service/remote/UserServiceClient.java
@@ -1,9 +1,11 @@
 package com.team9.question_service.remote;
 
 import com.team9.common.response.CustomResponse;
+import com.team9.question_service.dto.UserProfileResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
@@ -21,6 +23,6 @@ public interface UserServiceClient {
      * @param userId 조회할 사용자의 ID
      * @return CustomResponse 형태의 응답. 결과 데이터는 String 타입의 카테고리 이름 리스트입니다.
      */
-    @GetMapping("/internal/users/interests")
-    ResponseEntity<CustomResponse<List<String>>> getUserInterests(@RequestParam("userId") Long userId);
+    @GetMapping("/api/users/{userId}")
+    ResponseEntity<CustomResponse<UserProfileResponseDto>> getUserProfile(@PathVariable("userId") Long userId); // 2. 메서드명, 파라미터, 반환 타입 변경
 }

--- a/question-service/src/main/java/com/team9/question_service/service/QuestionService.java
+++ b/question-service/src/main/java/com/team9/question_service/service/QuestionService.java
@@ -6,6 +6,7 @@ import com.team9.common.exception.CustomException;
 import com.team9.common.response.CustomResponse;
 import com.team9.question_service.domain.Question;
 import com.team9.question_service.dto.QuestionResponse;
+import com.team9.question_service.dto.UserProfileResponseDto;
 import com.team9.question_service.repository.QuestionRepository;
 import com.team9.question_service.remote.AnswerServiceClient;
 import com.team9.question_service.remote.UserServiceClient; // UserServiceClient 임포트
@@ -143,21 +144,28 @@ public class QuestionService {
     // user-service 호출 및 예외 처리 로직
     private List<String> getUserInterests(Long userId) {
         try {
-            ResponseEntity<CustomResponse<List<String>>> responseEntity = userServiceClient.getUserInterests(userId);
+            // 1. 변경된 Feign Client 메서드를 호출합니다.
+            ResponseEntity<CustomResponse<UserProfileResponseDto>> responseEntity = userServiceClient.getUserProfile(userId);
+
+            // 2. 응답이 성공적인지, body가 null이 아닌지, isSuccess가 true인지 확인합니다.
             if (responseEntity.getStatusCode().is2xxSuccessful() && responseEntity.getBody() != null && responseEntity.getBody().isSuccess()) {
-                List<String> interests = responseEntity.getBody().getResult();
-                if (interests != null) {
+                UserProfileResponseDto userProfile = responseEntity.getBody().getResult();
+
+                // 3. 응답 DTO에서 관심사 목록을 추출합니다.
+                if (userProfile != null && userProfile.getInterestCategories() != null) {
+                    List<String> interests = userProfile.getInterestCategories();
                     log.info("user-service로부터 userId: {}의 관심 카테고리 {}개를 받았습니다.", userId, interests.size());
                     return interests;
                 }
             } else {
-                log.warn("user-service로부터 관심 카테고리 목록을 가져오는 데 실패했습니다. status: {}, body: {}",
+                log.warn("user-service로부터 사용자 프로필을 가져오는 데 실패했습니다. status: {}, body: {}",
                         responseEntity.getStatusCode(), responseEntity.getBody());
             }
         } catch (Exception e) {
             log.error("user-service 호출 중 에러 발생: userId={}", userId, e);
         }
-        return Collections.emptyList(); // 실패 시 빈 리스트 반환하여 NullPointerException 방지
+        // 실패 시 빈 리스트를 반환하여 NullPointerException을 방지합니다.
+        return Collections.emptyList();
     }
 
     private Set<Long> getSubmittedQuestionIds(Long userId) {


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 메인 페이지의 기존 '오늘의 질문' 대신 로그인한 사용자의 관심 카테고리에 맞는 CS 질문을 개인화하여 추천하는 기능을 구현합니다.

## 🔍 작업 상세 (Implementation Details)
- UserServiceClient 구현
> user-service의 GET /api/users/{userId} API를 호출하여 사용자의 관심 카테고리 목록을 조회하는 Feign Client를 구현합니다.
- QuestionService 로직 추가
> UserServiceClient와 AnswerServiceClient를 호출하여 필요한 데이터를 수집합니다.
>"관심 카테고리에 속하면서, 아직 답변하지 않은 질문"을 랜덤으로 1개 조회하는 비즈니스 로직을 작성합니다.
> 추천할 질문이 없을 경우(비로그인 or 관심 카테고리의 모든 질문에 답변함 등)에 대한 예외 처리 또는 대체 로직(Fallback)을 구현합니다.
- QuestionRepository 쿼리 추가
> 관심 카테고리 목록과 제외할 질문 ID 목록을 조건으로 랜덤 질문을 조회하는 커스텀 쿼리를 추가합니다.
- QuestionController 엔드포인트 추가