### PR TITLE
[Fix/#79] user-service 주석처리 해제

### DIFF
--- a/user-service/src/main/java/com/team9/user_service/security/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/team9/user_service/security/config/SecurityConfig.java
@@ -22,16 +22,17 @@ public class SecurityConfig {
         return http.getSharedObject(AuthenticationManagerBuilder.class).build();
     }
 
-//    @Bean
-//    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-//        http
-//                .csrf(csrf -> csrf.disable())
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/api/users/**").permitAll()
-//                        .requestMatchers("/backend/user/v1/**").permitAll()  // validate, exists 등 허용
-//                        .anyRequest().authenticated()
-//                );
-//
-//        return http.build();
-//    }
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/users/**").permitAll()
+                        .requestMatchers("/backend/user/v1/**").permitAll()  // validate, exists 등 허용
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- user-service에 있는 webSecurityConfig 주석처리를 해제했습니다


## 📝 추가 정보 (Additional Information)
- 시큐리티 의존성이 추가되어 있을 때 WebSecurityConfig가 설정 안되어 있으면 다 401로 막힌다는 정보를 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/actuator/**` 경로에 대한 접근이 인증 없이 허용됩니다.  
* **버그 수정**
  * 일부 경로에 대한 인증 및 보안 설정이 정상적으로 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->